### PR TITLE
Need to find_library libkunet.so, not libkunet

### DIFF
--- a/src/KUnet.jl
+++ b/src/KUnet.jl
@@ -1,5 +1,5 @@
 module KUnet
-const libkunet = find_library(["libkunet"], [Pkg.dir("KUnet/cuda")])
+const libkunet = find_library(["libkunet.so"], [Pkg.dir("KUnet/cuda")])
 
 using Compat
 using InplaceOps


### PR DESCRIPTION
Otherwise won't find library even if it is there, as of version 0.3