### PR TITLE
Compile to libkunet.dylib instead of libkunet.so on OS X

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@
 test1
 test2
 *.so
+*.dylib
 *.o
 foo*
 unused

--- a/REQUIRE
+++ b/REQUIRE
@@ -3,3 +3,4 @@ HDF5
 GZip
 ArgParse
 Compat
+Dates

--- a/cuda/Makefile
+++ b/cuda/Makefile
@@ -1,12 +1,19 @@
-CFLAGS=-g -L.
+UNAME := $(shell uname)
+ifeq ($(UNAME),Darwin)
+	EXT := dylib
+else
+	EXT := so
+endif
 
-all: libkunet.so libkunet_h5.so
+CFLAGS=-L.
 
-libkunet.so: kunet.o
-	nvcc $(CFLAGS) --shared --compiler-options -fPIC $^ -lcublas -lcurand -o $@
+all: libkunet libkunet_h5
 
-libkunet_h5.so: kunet_h5.o
-	nvcc $(CFLAGS) --shared --compiler-options -fPIC $^ -lhdf5 -lhdf5_hl -o $@
+libkunet: kunet.o
+	nvcc $(CFLAGS) --shared --compiler-options -fPIC $^ -lcublas -lcurand -o $@.$(EXT)
+
+libkunet_h5: kunet_h5.o
+	nvcc $(CFLAGS) --shared --compiler-options -fPIC $^ -lhdf5 -lhdf5_hl -o $@.$(EXT)
 
 kunet.o: kunet.cu kunet.h
 
@@ -16,4 +23,4 @@ kunet_h5.o: kunet_h5.cu kunet_h5.h kunet.h
 	nvcc -c $(CFLAGS) --compiler-options -fPIC $< -o $@
 
 clean:
-	-rm *.o *.so
+	-rm *.o *.$(EXT)

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -1,6 +1,6 @@
 try success(`nvcc --version`)
     cd("../src") do
-        run(`make libkunet.so`)
+        run(`make libkunet`)
     end
 catch
     warn("CUDA not installed, GPU support will not be available.")

--- a/src/Makefile
+++ b/src/Makefile
@@ -1,11 +1,18 @@
-#CFLAGS=-g -L.
+UNAME := $(shell uname)
+ifeq ($(UNAME),Darwin)
+	EXT := dylib
+else
+	EXT := so
+endif
+
+#CFLAGS=-L.
 CFLAGS=-O2
 
-libkunet.so: drop.o logp.o logploss.o param.o softloss.o xentloss.o percloss.o kperceptron.o cumatrix.o
-	nvcc $(CFLAGS) --shared --compiler-options -fPIC $^ -lcublas -lcurand -o $@
+libkunet: drop.o logp.o logploss.o param.o softloss.o xentloss.o percloss.o kperceptron.o cumatrix.o
+	nvcc $(CFLAGS) --shared --compiler-options -fPIC $^ -lcublas -lcurand -o $@.$(EXT)
 
 %.o: %.cu kunet.h
 	nvcc -c $(CFLAGS) --compiler-options -fPIC $< -o $@
 
 clean:
-	-rm *.o libkunet.so
+	-rm *.o *.$(EXT)


### PR DESCRIPTION
In pull #3 I pointed out an issue on OS X, where libkunet was not discovered because find_library expects .dylib, not .so. This updates the necessary files to handle compiling to .dylib on OS X instead.  

Also, the Dates library is required by mnist.jl.  